### PR TITLE
Fixes Android issue with looping and triggering callback on video end.

### DIFF
--- a/www/Html5Video.js
+++ b/www/Html5Video.js
@@ -7,7 +7,8 @@ Html5Video.prototype._callbacks = {};
 /*
  * videos - a map between html video tag ids and the file name of the video
  * they play. In addition, file names must be all lowercase, with only
- * alpha-numeric characters
+ * alpha-numeric characters 
+ * eg: {"video1":"video1file.mp4", "video2":"video2file.mp4"}
  */
 Html5Video.prototype.initialize = function(videos) {
 	var me = this;
@@ -26,8 +27,8 @@ Html5Video.prototype.initialize = function(videos) {
 };
 
 /*
- * videoId - the html video tag id of the video to play callback - a
- * function that is called when the video has finished playing
+ * videoId - the html video tag id of the video to play 
+ * callback - a function that is called when the video has finished playing
  */
 Html5Video.prototype.play = function(videoId, callback) {
 	var me = this;
@@ -39,7 +40,7 @@ Html5Video.prototype.play = function(videoId, callback) {
 			console.error('html video error: ' + err);
 		}, 'Html5Video', 'play', [ videoId ]);
 	} else {
-		this._playVideo(document.getElementById(videoId));
+		this._play(document.getElementById(videoId));
 	}
 }
 
@@ -50,15 +51,17 @@ Html5Video.prototype._play = function(video) {
 	video.src = me._videos[videoId];
 	//video.setAttribute('poster', video.getAttribute('poster'));		
 
-	if (!!me._callbacks[videoId]) {
-		video.addEventListener("timeupdate", function() {
-			if (video.duration > 0
-					&& video.duration - video.currentTime == 0) {
-				video.removeEventListener("timeupdate", this, false);
-				me._callbacks[videoId](video);
-			}
-		}, false);
-	}
+	video.addEventListener("timeupdate", function() {
+		if (video.duration > 0 
+			&& Math.round(video.duration) - Math.round(video.currentTime) == 0) {
+			
+			//if loop atribute is set, restart video
+			if (video.loop) video.currentTime = 0;
+			
+			//if a callback function was set, trigger it
+			if (!!me._callbacks[videoId]) me._callbacks[videoId](video);
+		}
+	}, false);
 	
 	video.addEventListener("canplay", function(){
 		video.removeEventListener("canplay", this, false);


### PR DESCRIPTION
**Fixes Android issue with looping and triggering callback on video end.**

Added example of the expected format for the videos parameter in the initialize method.
Renamed _playVideo() call in the initialize method to _play().
Rounded video.duration and video.currentTime values to trigger video.ended callback and force loop the video, if requested on the video tag.
